### PR TITLE
chore: include Grafana k8s-monitoring chart

### DIFF
--- a/charts/cluster-apps/Chart.lock
+++ b/charts/cluster-apps/Chart.lock
@@ -17,5 +17,8 @@ dependencies:
 - name: promtail
   repository: https://grafana.github.io/helm-charts
   version: 6.17.0
-digest: sha256:01b796e18ca9ab4152d78ac882f324a42e98e1107d400754e66bd101bddca8b5
-generated: "2025-10-03T08:53:29.066048293+07:00"
+- name: k8s-monitoring
+  repository: https://grafana.github.io/helm-charts
+  version: 4.1.0
+digest: sha256:199cd985c07acca4edf1b2c854bd21817fa7040fd1bef4eb49cb834e2ba79d5b
+generated: "2026-05-08T04:09:33.100563684+07:00"

--- a/charts/cluster-apps/Chart.yaml
+++ b/charts/cluster-apps/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -27,18 +27,28 @@ dependencies:
   - name: ingress-nginx
     version: 4.11.3
     repository: https://kubernetes.github.io/ingress-nginx
+    condition: ingress-nginx.enabled
   - name: cert-manager
     version: 1.16.1
     repository: https://charts.jetstack.io
+    condition: cert-manager.enabled
   - name: metrics-server
     version: 3.12.2
     repository: https://kubernetes-sigs.github.io/metrics-server
+    condition: metrics-server.enabled
   - name: kube-prometheus-stack
     version: 65.5.0
     repository: https://prometheus-community.github.io/helm-charts
+    condition: kube-prometheus-stack.enabled
   - name: loki
     version: 6.42.0
     repository: https://grafana.github.io/helm-charts
+    condition: loki.enabled
   - name: promtail
     version: 6.17.0
     repository: https://grafana.github.io/helm-charts
+    condition: promtail.enabled
+  - name: k8s-monitoring
+    version: 4.1.0
+    repository: https://grafana.github.io/helm-charts
+    condition: k8s-monitoring.enabled

--- a/charts/cluster-apps/values.yaml
+++ b/charts/cluster-apps/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 ingress-nginx:
+  enabled: true
   controller:
     service:
       annotations:
@@ -20,6 +21,7 @@ ingress-nginx:
           release: cluster-apps
 
 cert-manager:
+  enabled: true
   installCRDs: true
 
 cert-issuer-prod:
@@ -28,7 +30,11 @@ cert-issuer-prod:
   # Unsetting the ingressClass value, in order to use default ingress class.
   ingressClass: ""
 
+metrics-server:
+  enabled: true
+
 kube-prometheus-stack:
+  enabled: true
   grafana:
     persistence:
       enabled: true
@@ -58,6 +64,7 @@ kube-prometheus-stack:
       serviceMonitorSelectorNilUsesHelmValues: false
 
 loki:
+  enabled: true
   loki:
     commonConfig:
       replication_factor: 1
@@ -87,6 +94,7 @@ loki:
     replicas: 1
 
 promtail:
+  enabled: true
   config:
     clients:
       - url: http://{{ .Release.Name }}-loki:3100/loki/api/v1/push
@@ -107,3 +115,9 @@ promtail:
               target_label: container
             - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
               target_label: instance
+
+k8s-monitoring:
+  enabled: false
+  cluster:
+    name: ""
+  destinations: []


### PR DESCRIPTION
I'm adding the Grafana k8s-monitoring to our cluster apps chart with the intention of installing it on our Hetzner cluster. The long term goal is to setup monitoring within the Hetzner cluster and aggregate logs from EKS and other clusters.

Conditional deploy is introduced for all charts for the sake of backwards compatibility.